### PR TITLE
NullPointer Patch

### DIFF
--- a/init.js
+++ b/init.js
@@ -40,6 +40,8 @@
             this.load();
             //Set subscriptions
             amplify.subscribe('active.onOpen', function(path){
+	    	if(codiad.editor.getActive() === null)
+			return;
                 var manager = codiad.editor.getActive().commands;
                 manager.addCommand({
                     name: "Beautify",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 [{
 	"author": "Andr3as",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"name": "Beautify",
 	"url": "https://github.com/Andr3as/Codiad-Beautify",
 	"config": [{


### PR DESCRIPTION
I saw that when Codiad loads it prints a exception in the console.

This is the fix for the Null Pointer in  `init.js:43`

```
The Null Pointer wont effect the work state of Beautify, but it exists while it shouldn't. Merge on your own will.
```